### PR TITLE
feat: `info` is added to print the connected device

### DIFF
--- a/bluetooth.md
+++ b/bluetooth.md
@@ -2,10 +2,16 @@
 ```shell
 bluetoothctl -- list
 bluetoothctl -- scan on
+
+# set at first connection (pairing)
 bluetoothctl -- pair XX:XX:XX:XX:XX:XX
 bluetoothctl -- trust XX:XX:XX:XX:XX:XX
 
+# set at second time and later
 bluetoothctl -- disconnect XX:XX:XX:XX:XX:XX
 bluetoothctl -- connect XX:XX:XX:XX:XX:XX
+
+# check whether it is connected
+bluetoothctl -- info
 ```
 


### PR DESCRIPTION
### Content
- `bluetoothctl -- info` is added

### Differences

### References

### Tests